### PR TITLE
Add IDisposable implementation to ILayoutBuilderFactory

### DIFF
--- a/PdfLibSharp.Tests/LayoutBuilderFactoryTests.cs
+++ b/PdfLibSharp.Tests/LayoutBuilderFactoryTests.cs
@@ -5,7 +5,7 @@ using PdfLibSharp.Layout;
 
 namespace PdfLibSharp.Tests;
 
-public class LayoutBuilderTests
+public class LayoutBuilderFactoryTests
 {
     private IMeasureGraphics _measureGraphics;
     private LayoutScope _layoutScope;

--- a/PdfLibSharp.Tests/LayoutBuilderFactoryTests.cs
+++ b/PdfLibSharp.Tests/LayoutBuilderFactoryTests.cs
@@ -49,4 +49,11 @@ public class LayoutBuilderFactoryTests
         Assert.That(layoutBuilder, Is.InstanceOf<ImageLayoutBuilder>());
         Assert.That(layoutBuilder.Element, Is.EqualTo(imageElement)); 
     }
+
+    [Test]
+    public void LayoutBuilderFactory_Dispose()
+    {
+        var layoutBuilderFactory = new LayoutBuilderFactory(_measureGraphics);
+        layoutBuilderFactory.Dispose();
+    }
 }

--- a/PdfLibSharp/Layout/ILayoutBuilderFactory.cs
+++ b/PdfLibSharp/Layout/ILayoutBuilderFactory.cs
@@ -3,7 +3,7 @@ using PdfLibSharp.Drawing;
 
 namespace PdfLibSharp.Layout;
 
-internal interface ILayoutBuilderFactory
+internal interface ILayoutBuilderFactory : IDisposable
 {
     ILayoutBuilder GetLayoutBuilder(IElement element, LayoutScope scope);
 }

--- a/PdfLibSharp/Layout/LayoutBuilderFactory.cs
+++ b/PdfLibSharp/Layout/LayoutBuilderFactory.cs
@@ -18,4 +18,9 @@ internal class LayoutBuilderFactory(IMeasureGraphics measureGraphics) : ILayoutB
             _ => throw new ArgumentOutOfRangeException(nameof(element), element, "Unsupported element type")
         };
     }
+
+    public void Dispose()
+    {
+        measureGraphics.Dispose();
+    }
 }


### PR DESCRIPTION
### Description
- Implement IDisposable interface in the ILayoutBuilderFactory to ensure proper resource cleanup.
- Renamed LayoutBuilderTests to LayoutBuilderFactoryTests for better alignment with the class focus.