### PR TITLE
Bumped nuget to alpha3 (even though I didn't need to)

### DIFF
--- a/PdfLibSharp/PdfLibSharp.csproj
+++ b/PdfLibSharp/PdfLibSharp.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
         <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
-        <Version>1.0.0-alpha2</Version>
+        <Version>1.0.0-alpha3</Version>
         <Title>PdfLibSharp</Title>
         <Authors>Ryan Esteves</Authors>
         <Description>A wrapper around PdfSharp that supports auto sizing stacks of elements</Description>


### PR DESCRIPTION
Had some issues with nuget cache on my pc and ended up uploading alpha3 to nuget.org even though there ended up being no difference between 2 and 3. /shrug