### PR TITLE
Remove caching logic from LayoutModel creation

### DIFF
--- a/PdfLibSharp/Layout/BaseLayoutModelFactory.cs
+++ b/PdfLibSharp/Layout/BaseLayoutModelFactory.cs
@@ -9,16 +9,12 @@ internal abstract class BaseLayoutModelFactory : ILayoutModelFactory
 
     public LayoutModel CreateLayoutModel(IElement element, Size constraints, LayoutScope scope)
     {
-        if (_cachedLayouts.TryGetValue(constraints, out LayoutModel? layout))
-            return layout;
-
         Size innerConstraints = constraints - element.Margins.ToSize();
         innerConstraints = element.GetSize(innerConstraints);
 
         ContentModel contentModel = CreateContentModel(element, innerConstraints, scope);
 
-        return _cachedLayouts[constraints] =
-            new LayoutModel(contentModel, element.Margins, element.Sizing, element.Width, element.Height);
+        return new LayoutModel(contentModel, element.Margins, element.Sizing, element.Width, element.Height);
     }
 
     protected abstract ContentModel CreateContentModel(IElement element, Size constraints, LayoutScope scope);


### PR DESCRIPTION
Fixes unintentional duplication when two elements have the same constraints